### PR TITLE
Refines structure for fontainbleau::Grade

### DIFF
--- a/src/grades/fontainebleau/mod.rs
+++ b/src/grades/fontainebleau/mod.rs
@@ -3,4 +3,4 @@
 //! The primarily European grading system developed in Fontainebleau, France.
 
 mod grade;
-pub use grade::Grade;
+pub use grade::*;


### PR DESCRIPTION
Refines structure for fontainbleau::Grade by adding `fontainbleau::Division`. This allows for less ambiguity when creating grades.