### PR TITLE
Timepoint values to include year when necessary

### DIFF
--- a/src/ascent/ascent.rs
+++ b/src/ascent/ascent.rs
@@ -28,20 +28,40 @@ pub struct Person {
     pub last_name: String,
 }
 
-/// Temporal unit meant to describe a point in time
+/// Temporal unit meant to describe a point in time at varying granularity
 #[derive(PartialEq, PartialOrd)]
 pub enum TimePoint {
     /// Specifies some year
     Year(u16),
 
     /// Specifies some season
-    Season(Season),
+    Season(SeasonTimePoint),
 
     /// Specifies some month
-    Month(chrono::Month),
+    Month(MonthTimePoint),
 
     /// Specifies some date
-    Date(chrono::NaiveDate)
+    Date(chrono::NaiveDate),
+}
+
+/// Temporal unit meant to describe a specific season
+#[derive(PartialEq, PartialOrd)]
+pub struct SeasonTimePoint {
+    /// The year which the season took place
+    pub year: u16,
+
+    /// The season of the year
+    pub season: Season,
+}
+
+/// Temporal unit meant to describe a specific month
+#[derive(PartialEq, PartialOrd)]
+pub struct MonthTimePoint {
+    /// The year which the month took place
+    pub year: u16,
+
+    /// The month of the year
+    pub month: chrono::Month
 }
 
 /// Enumeration of the four common seasons of the year


### PR DESCRIPTION
The timepoint enumerations Season and Month previously only contained data for a season and a month. These are not useful without knowing which year they are occurred in. Two new structs, SeasonTimepoint and MonthTimepoint were added to accomodate for this.