### PR TITLE
Prefix Fontainebleau display string with "F"

### DIFF
--- a/src/grades/fontainebleau/grade.rs
+++ b/src/grades/fontainebleau/grade.rs
@@ -87,7 +87,7 @@ impl fmt::Display for Division {
 
 impl fmt::Display for Fontainebleau {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.level)?;
+        write!(f, "F{}", self.level)?;
 
         match &self.division {
             Some(division) => write!(f, "{}", division),

--- a/src/grades/fontainebleau/grade/display_tests.rs
+++ b/src/grades/fontainebleau/grade/display_tests.rs
@@ -2,20 +2,20 @@ use super::*;
 
 #[test]
 fn level() {
-    assert_eq!(Fontainebleau::new(1, None, false).expect("Good value").to_string(), "1");
+    assert_eq!(Fontainebleau::new(1, None, false).expect("Good value").to_string(), "F1");
 }
 
 #[test]
 fn level_plus() {
-    assert_eq!(Fontainebleau::new(1, None, true).expect("Good value").to_string(), "1+");
+    assert_eq!(Fontainebleau::new(1, None, true).expect("Good value").to_string(), "F1+");
 }
 
 #[test]
 fn level_division() {
-    assert_eq!(Fontainebleau::new(6, Some(Division::A), false).expect("Good value").to_string(), "6A");
+    assert_eq!(Fontainebleau::new(6, Some(Division::A), false).expect("Good value").to_string(), "F6A");
 }
 
 #[test]
 fn level_division_plus() {
-    assert_eq!(Fontainebleau::new(7, Some(Division::B), true).expect("Good value").to_string(), "7B+");
+    assert_eq!(Fontainebleau::new(7, Some(Division::B), true).expect("Good value").to_string(), "F7B+");
 }


### PR DESCRIPTION
The Fontainebleau bouldering grade is generally prefixed with "F" to differentiate it with the French route grades (which are generally prefixed with "f").